### PR TITLE
Fix #4, add tests

### DIFF
--- a/tests/test.proto
+++ b/tests/test.proto
@@ -1,0 +1,7 @@
+message TestProto {
+    optional uint64 a = 1;
+    repeated uint32 b = 2;
+    optional uint32 c = 3;
+    required bool d = 4;
+    optional bytes e = 5;
+}

--- a/tests/test_pb.py
+++ b/tests/test_pb.py
@@ -1,0 +1,17 @@
+from protobuf_utils import *
+
+class TestProto(Message):
+    a = None
+    b = None
+    c = None
+    d = None
+    e = None
+
+    def __init__(self):
+        self.__lookup__ = [("optional", type_uint64, "a", 1),
+                           ("repeated", type_uint32, "b", 2),
+                           ("optional", type_uint32, "c", 3),
+                           ("required", type_bool, "d", 4),
+                           ("optional", type_bytes, "e", 5)]
+
+

--- a/tests/test_protopy.py
+++ b/tests/test_protopy.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from test_pb import *
+
+
+class TestProtoPy(unittest.TestCase):
+    def test_encode_dict(self):
+        raw_dict = {'a': 123456, 'b': [1, 2, 3, 4], 'd': False, 'e': 'tiny pure python protobuf implementation'}
+        test_obj = TestProto()
+        test_obj.__dict__.update(raw_dict)
+        buf1 = test_obj.encode()
+        buf2 = encode_raw_dict(TestProto, raw_dict)
+        self.assertEqual(buf1, buf2)


### PR DESCRIPTION
However, this patch doesn't work perfectly, because of the `__lookup__` isn't a class variable, `encode_raw_dict` will construct the message class every time.
